### PR TITLE
new:usr:Improve Dblint resource parameters and responses

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.0</version>
+                <version>3.0.0-M1</version>
                 <configuration>
                     <systemPropertyVariables>
                         <org.slf4j.simpleLogger.logFile>${project.build.directory}/test.log</org.slf4j.simpleLogger.logFile>

--- a/server/src/main/java/com/dblint/server/pojo/QueryResponse.java
+++ b/server/src/main/java/com/dblint/server/pojo/QueryResponse.java
@@ -1,0 +1,62 @@
+package com.dblint.server.pojo;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+public class QueryResponse {
+  public final String sql;
+  public final String errorMessage;
+  public final boolean success;
+
+  /**
+   * Create a query response object.
+   * @param response Response or error message
+   * @param success Boolean if processing was successful
+   */
+  public QueryResponse(String response, boolean success) {
+    this.success = success;
+    if (success) {
+      this.sql = response;
+      this.errorMessage = null;
+    } else {
+      this.errorMessage = response;
+      this.sql = null;
+    }
+  }
+
+  /**
+   * Create response object from json strings.
+   * @param sql SQL string in response
+   * @param errorMessage Error message if processing failed
+   * @param success Whether processing was successful
+   */
+  @JsonCreator
+  public QueryResponse(@JsonProperty("sql") String sql,
+                       @JsonProperty("errorMessage") String errorMessage,
+                       @JsonProperty("success") boolean success) {
+    this.sql = sql;
+    this.errorMessage = errorMessage;
+    this.success = success;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null || getClass() != obj.getClass()) {
+      return false;
+    }
+    QueryResponse that = (QueryResponse) obj;
+    return success == that.success
+       && Objects.equals(sql, that.sql)
+       && Objects.equals(errorMessage, that.errorMessage);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(sql, errorMessage, success);
+  }
+}

--- a/server/src/main/java/com/dblint/server/pojo/SqlQuery.java
+++ b/server/src/main/java/com/dblint/server/pojo/SqlQuery.java
@@ -1,0 +1,20 @@
+package com.dblint.server.pojo;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class SqlQuery {
+  public final String sql;
+  public final String dialect;
+
+  public SqlQuery(String sql) {
+    this(sql, "mysql");
+  }
+
+  @JsonCreator
+  public SqlQuery(@JsonProperty("sql") String sql,
+                  @JsonProperty("dialect") String dialect) {
+    this.sql = sql;
+    this.dialect = dialect;
+  }
+}

--- a/server/src/main/java/com/dblint/server/resources/DbLintResource.java
+++ b/server/src/main/java/com/dblint/server/resources/DbLintResource.java
@@ -2,6 +2,8 @@ package com.dblint.server.resources;
 
 import com.codahale.metrics.annotation.ExceptionMetered;
 import com.codahale.metrics.annotation.Metered;
+import com.dblint.server.pojo.QueryResponse;
+import com.dblint.server.pojo.SqlQuery;
 import com.dblint.sqlplanner.planner.Parser;
 import org.apache.calcite.sql.SqlDialect;
 import org.apache.calcite.sql.parser.SqlParseException;
@@ -20,19 +22,41 @@ public class DbLintResource {
     this.parser = parser;
   }
 
+  /**
+   * Return a digest of the Sql Query.
+   * @param sql SqlQuery object with SQL string and other properties
+   * @return SQL Digest if successful else an error message
+   */
   @POST
   @Path("/digest")
   @Metered
   @ExceptionMetered
-  public String digest(String sql) throws SqlParseException {
-    return parser.digest(sql, SqlDialect.DatabaseProduct.MYSQL.getDialect());
+  public QueryResponse digest(SqlQuery sql) {
+    try {
+      String digest = parser.digest(sql.sql,
+              SqlDialect.DatabaseProduct.valueOf(sql.dialect.toUpperCase()).getDialect());
+      return new QueryResponse(digest, true);
+    } catch (Exception exc) {
+      return new QueryResponse(exc.getMessage(), false);
+    }
   }
 
+  /**
+   * Return a pretty of the Sql Query.
+   * @param sql SqlQuery object with SQL string and other properties
+   * @return Pretty Printed if successful else an error message
+   */
   @POST
   @Path("/pretty")
   @Metered
   @ExceptionMetered
-  public String pretty(String sql) throws SqlParseException {
-    return parser.pretty(sql, SqlDialect.DatabaseProduct.MYSQL.getDialect());
+  public QueryResponse pretty(SqlQuery sql) {
+    try {
+      String pretty = parser.pretty(sql.sql,
+              SqlDialect.DatabaseProduct.valueOf(sql.dialect.toUpperCase()).getDialect());
+      return new QueryResponse(pretty, true);
+    } catch (Exception exc) {
+      return new QueryResponse(exc.getMessage(), false);
+    }
   }
 }

--- a/server/src/test/java/com/dblint/server/pojo/QueryResponseTest.java
+++ b/server/src/test/java/com/dblint/server/pojo/QueryResponseTest.java
@@ -1,0 +1,59 @@
+package com.dblint.server.pojo;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class QueryResponseTest {
+  private static QueryResponse success;
+  private static QueryResponse error;
+
+  @BeforeAll
+  static void setResponse() {
+    success = new QueryResponse("select", true);
+    error = new QueryResponse("errMsg", false);
+  }
+
+  static Stream<Arguments> responseProvider() {
+    return Stream.of(
+      Arguments.arguments(success, "{\"sql\":\"select\","
+            + "\"errorMessage\":null,\"success\":true}"),
+        Arguments.arguments(error, "{\"sql\":null,"
+            + "\"errorMessage\":\"errMsg\",\"success\":false}")
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("responseProvider")
+  void serialize(QueryResponse response, String expected)
+      throws JsonProcessingException {
+    String serialized = new ObjectMapper().writeValueAsString(response);
+    assertEquals(expected, serialized);
+  }
+
+  static Stream<Arguments> stringProvider() {
+    return Stream.of(
+      Arguments.arguments(success, "{\"sql\":\"select\","
+            + "\"errorMessage\":null,\"success\":true}"),
+        Arguments.arguments(error, "{\"sql\":null,"
+            + "\"errorMessage\":\"errMsg\",\"success\":false}")
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("stringProvider")
+  void deSerialize(QueryResponse expected, String response)
+      throws IOException {
+    QueryResponse deserialized = new ObjectMapper().readValue(response, QueryResponse.class);
+    assertEquals(deserialized, expected);
+  }
+}

--- a/server/src/test/java/com/dblint/server/resources/DbLintResourceTest.java
+++ b/server/src/test/java/com/dblint/server/resources/DbLintResourceTest.java
@@ -1,9 +1,10 @@
 package com.dblint.server.resources;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import javax.ws.rs.client.Entity;
 
+import com.dblint.server.pojo.QueryResponse;
+import com.dblint.server.pojo.QueryResponseTest;
+import com.dblint.server.pojo.SqlQuery;
 import com.dblint.sqlplanner.planner.Parser;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
@@ -15,6 +16,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
 public class DbLintResourceTest {
@@ -41,36 +44,56 @@ public class DbLintResourceTest {
   @Test
   public void callDigestTest() throws Throwable {
     RESOURCE.before();
-    String sql = "select a from t where i = 5";
-    String response = RESOURCE.target("/api/dblint/digest")
-        .request().post(Entity.json(sql)).readEntity(String.class);
+    SqlQuery sql = new SqlQuery("select a from t where i = 5");
+    QueryResponse response = RESOURCE.target("/api/dblint/digest")
+        .request().post(Entity.json(sql)).readEntity(QueryResponse.class);
     assertEquals(
         "SELECT `A`\n" +
             "FROM `T`\n" +
-            "WHERE `I` = ?", response);
+            "WHERE `I` = ?", response.sql);
+    assertTrue(response.success);
+    assertNull(response.errorMessage);
     RESOURCE.after();
   }
 
-  @Disabled
   @Test
   public void exceptionTest() throws Throwable {
     RESOURCE.before();
-    String response = RESOURCE.target("/api/dblint/digest")
-        .request().post(Entity.json("select a from where i")).readEntity(String.class);
-    assertEquals("Redshift HighCpuEvent Capture initiated", response);
+    SqlQuery sql = new SqlQuery("select a from where i = 5");
+    QueryResponse response = RESOURCE.target("/api/dblint/digest")
+        .request().post(Entity.json(sql)).readEntity(QueryResponse.class);
+    assertEquals("Encountered \"from where\" at line 1, column 10.",
+        response.errorMessage.split("\n")[0]);
+    assertFalse(response.success);
+    assertNull(response.sql);
     RESOURCE.after();
   }
 
   @Test
   public void callPrettyTest() throws Throwable {
     RESOURCE.before();
-    String sql = "select a from t where i = 5";
-    String response = RESOURCE.target("/api/dblint/pretty")
-        .request().post(Entity.json(sql)).readEntity(String.class);
+    SqlQuery sql = new SqlQuery("select a from t where i = 5");
+    QueryResponse response = RESOURCE.target("/api/dblint/pretty")
+        .request().post(Entity.json(sql)).readEntity(QueryResponse.class);
     assertEquals(
         "SELECT `A`\n" +
             "FROM `T`\n" +
-            "WHERE `I` = 5", response);
+            "WHERE `I` = 5", response.sql);
+    assertTrue(response.success);
+    assertNull(response.errorMessage);
+    RESOURCE.after();
+  }
+
+  @Test
+  public void badDialectTest() throws Throwable {
+    RESOURCE.before();
+    SqlQuery sql = new SqlQuery("select a from t where i = 5", "someDialect");
+    QueryResponse response = RESOURCE.target("/api/dblint/pretty")
+        .request().post(Entity.json(sql)).readEntity(QueryResponse.class);
+    assertEquals("No enum constant org.apache.calcite.sql.SqlDialect.DatabaseProduct.SOMEDIALECT",
+        response.errorMessage);
+    assertFalse(response.success);
+    assertNull(response.sql);
     RESOURCE.after();
   }
 }


### PR DESCRIPTION
Use classes (SqlQuery and QueryResponse) instead of strings for
REST calls to digest and pretty print.