### PR TITLE
new:usr:Capture Git state during build. Expose through API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,6 @@
                     </execution>
                 </executions>
             </plugin>
-        </plugins>
+       </plugins>
     </build>
 </project>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -87,6 +87,13 @@
                 <targetPath>${project.build.directory}/config</targetPath>
                 <filtering>true</filtering>
             </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>**/*.properties</include>
+                </includes>
+            </resource>
         </resources>
         <plugins>
             <plugin>
@@ -118,6 +125,32 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
+                <version>2.2.5</version>
+                <executions>
+                    <execution>
+                        <id>get-the-git-infos</id>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
+                    <generateGitPropertiesFile>true</generateGitPropertiesFile>
+                    <generateGitPropertiesFilename>
+                        ${project.build.outputDirectory}/git.properties
+                    </generateGitPropertiesFilename>
+                    <format>json</format>
+                    <gitDescribe>
+                        <always>true</always>
+                        <dirty>-dirty</dirty>
+                    </gitDescribe>
+                    <skip>false</skip>
+                </configuration>
             </plugin>
         </plugins>
     </build>
@@ -156,7 +189,7 @@
                             <skip>true</skip>
                         </configuration>
                     </plugin>
-                </plugins>
+               </plugins>
             </build>
         </profile>
     </profiles>

--- a/server/src/main/java/com/dblint/server/pojo/GitState.java
+++ b/server/src/main/java/com/dblint/server/pojo/GitState.java
@@ -1,0 +1,99 @@
+package com.dblint.server.pojo;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class GitState {
+  public final String tags;
+  public final String branch;
+  public final String dirty;
+  public final String remoteOriginUrl;
+
+  public final String commitId;
+  public final String commitIdAbbrev;
+  public final String describe;
+  public final String describeShort;
+  public final String commitUserName;
+  public final String commitUserEmail;
+  public final String commitMessageFull;
+  public final String commitMessageShort;
+  public final String commitTime;
+  public final String closestTagName;
+  public final String closestTagCommitCount;
+
+  public final String buildUserName;
+  public final String buildUserEmail;
+  public final String buildTime;
+  public final String buildHost;
+  public final String buildVersion;
+  public final String totalCommitCount;
+
+  /**
+   * Capture git information from the project for introspection.
+   * @param tags  =${git.tags} comma separated tag names
+   * @param branch =${git.branch}
+   * @param dirty =${git.dirty}
+   * @param remoteOriginUrl =${git.remote.origin.url}
+   * @param commitId =${git.commit.id.full} OR ${git.commit.id}
+   * @param commitIdAbbrev =${git.commit.id.abbrev}
+   * @param describe =${git.commit.id.describe}
+   * @param describeShort =${git.commit.id.describe-short}
+   * @param commitUserName =${git.commit.user.name}
+   * @param commitUserEmail =${git.commit.user.email}
+   * @param commitMessageFull =${git.commit.message.full}
+   * @param commitMessageShort =${git.commit.message.short}
+   * @param commitTime =${git.commit.time}
+   * @param closestTagName =${git.closest.tag.name}
+   * @param closestTagCommitCount =${git.closest.tag.commit.count}
+   * @param buildUserName =${git.build.user.name}
+   * @param buildUserEmail =${git.build.user.email}
+   * @param buildTime =${git.build.time}
+   * @param buildHost =${git.build.host}
+   * @param buildVersion =${git.build.version}
+   * @param totalCommitCount =${git.total.commit.count}
+   */
+  @JsonCreator
+  public GitState(@JsonProperty("git.tags") String tags,
+                  @JsonProperty("git.branch") String branch,
+                  @JsonProperty("git.dirty") String dirty,
+                  @JsonProperty("git.remote.origin.url") String remoteOriginUrl,
+                  @JsonProperty("git.commit.id") String commitId,
+                  @JsonProperty("git.commit.id.abbrev") String commitIdAbbrev,
+                  @JsonProperty("git.commit.id.describe") String describe,
+                  @JsonProperty("git.commit.id.describe-short") String describeShort,
+                  @JsonProperty("git.commit.user.name") String commitUserName,
+                  @JsonProperty("git.commit.user.email") String commitUserEmail,
+                  @JsonProperty("git.commit.message.full") String commitMessageFull,
+                  @JsonProperty("git.commit.message.short") String commitMessageShort,
+                  @JsonProperty("git.commit.time") String commitTime,
+                  @JsonProperty("git.closest.tag.name") String closestTagName,
+                  @JsonProperty("git.closest.tag.commit.count") String closestTagCommitCount,
+                  @JsonProperty("git.build.user.name") String buildUserName,
+                  @JsonProperty("git.build.user.email") String buildUserEmail,
+                  @JsonProperty("git.build.time") String buildTime,
+                  @JsonProperty("git.build.host") String buildHost,
+                  @JsonProperty("git.build.version") String buildVersion,
+                  @JsonProperty("git.total.commit.count") String totalCommitCount) {
+    this.tags = tags;
+    this.branch = branch;
+    this.dirty = dirty;
+    this.remoteOriginUrl = remoteOriginUrl;
+    this.commitId = commitId;
+    this.commitIdAbbrev = commitIdAbbrev;
+    this.describe = describe;
+    this.describeShort = describeShort;
+    this.commitUserName = commitUserName;
+    this.commitUserEmail = commitUserEmail;
+    this.commitMessageFull = commitMessageFull;
+    this.commitMessageShort = commitMessageShort;
+    this.commitTime = commitTime;
+    this.closestTagName = closestTagName;
+    this.closestTagCommitCount = closestTagCommitCount;
+    this.buildUserName = buildUserName;
+    this.buildUserEmail = buildUserEmail;
+    this.buildTime = buildTime;
+    this.buildHost = buildHost;
+    this.buildVersion = buildVersion;
+    this.totalCommitCount = totalCommitCount;
+  }
+}

--- a/server/src/main/java/com/dblint/server/resources/DbLintResource.java
+++ b/server/src/main/java/com/dblint/server/resources/DbLintResource.java
@@ -2,12 +2,13 @@ package com.dblint.server.resources;
 
 import com.codahale.metrics.annotation.ExceptionMetered;
 import com.codahale.metrics.annotation.Metered;
+import com.dblint.server.pojo.GitState;
 import com.dblint.server.pojo.QueryResponse;
 import com.dblint.server.pojo.SqlQuery;
 import com.dblint.sqlplanner.planner.Parser;
 import org.apache.calcite.sql.SqlDialect;
-import org.apache.calcite.sql.parser.SqlParseException;
 
+import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -17,9 +18,11 @@ import javax.ws.rs.core.MediaType;
 @Produces(MediaType.APPLICATION_JSON)
 public class DbLintResource {
   final Parser parser;
+  final GitState gitState;
 
-  public DbLintResource(Parser parser) {
+  public DbLintResource(Parser parser, GitState gitState) {
     this.parser = parser;
+    this.gitState = gitState;
   }
 
   /**
@@ -58,5 +61,12 @@ public class DbLintResource {
     } catch (Exception exc) {
       return new QueryResponse(exc.getMessage(), false);
     }
+  }
+
+  @GET
+  @Path("/version")
+  @Metered
+  public GitState version() {
+    return gitState;
   }
 }

--- a/server/src/test/java/com/dblint/server/pojo/GitStateTest.java
+++ b/server/src/test/java/com/dblint/server/pojo/GitStateTest.java
@@ -1,0 +1,44 @@
+package com.dblint.server.pojo;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class GitStateTest {
+  private static String json = "{\n"
+      + "\"git.branch\" : \"json-response\",\n"
+      + "\"git.build.host\" : \"build-machine\",\n"
+      + "\"git.build.time\" : \"2018-11-22T22:33:26+0530\",\n"
+      + "\"git.build.user.email\" : \"xxxxxx@yyyyyyy.io\",\n"
+      + "\"git.build.user.name\" : \"User Name\",\n"
+      + "\"git.build.version\" : \"0.4.3-SNAPSHOT\",\n"
+      + "\"git.closest.tag.commit.count\" : \"\",\n"
+      + "\"git.closest.tag.name\" : \"\",\n"
+      + "\"git.commit.id\" : \"28010b73bae868ba252fbf2974f93d30ae189ea0\",\n"
+      + "\"git.commit.id.abbrev\" : \"28010b7\",\n"
+      + "\"git.commit.id.describe\" : \"28010b7-dirty\",\n"
+      + "\"git.commit.id.describe-short\" : \"28010b7-dirty\",\n"
+      + "\"git.commit.message.full\" : \"new:usr:Improve Dblint resource parameters and "
+        + "responses\\n\\nUse classes (SqlQuery and QueryResponse) instead of strings for\\nREST "
+        + "calls to digest and pretty print.\",\n"
+      + "\"git.commit.message.short\" : \"new:usr:Improve Dblint resource parameters and "
+        + "responses\",\n"
+      + "\"git.commit.time\" : \"2018-11-22T21:24:13+0530\",\n"
+      + "\"git.commit.user.email\" : \"xxxxx@xxxxx.io\",\n"
+      + "\"git.commit.user.name\" : \"User Name\",\n"
+      + "\"git.dirty\" : \"true\",\n"
+      + "\"git.remote.origin.url\" : \"git@github.com:vrajat/mart.git\",\n"
+      + "\"git.tags\" : \"\",\n"
+      + "\"git.total.commit.count\" : \"94\"\n"
+      + "}";
+
+  @Test
+  void deSerialize() throws IOException {
+    GitState gitState = new ObjectMapper().readValue(json, GitState.class);
+    assertEquals("0.4.3-SNAPSHOT", gitState.buildVersion);
+    assertEquals("28010b7-dirty", gitState.describe);
+  }
+}

--- a/server/src/test/java/com/dblint/server/resources/DbLintResourceTest.java
+++ b/server/src/test/java/com/dblint/server/resources/DbLintResourceTest.java
@@ -2,8 +2,8 @@ package com.dblint.server.resources;
 
 import javax.ws.rs.client.Entity;
 
+import com.dblint.server.pojo.GitState;
 import com.dblint.server.pojo.QueryResponse;
-import com.dblint.server.pojo.QueryResponseTest;
 import com.dblint.server.pojo.SqlQuery;
 import com.dblint.sqlplanner.planner.Parser;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -13,21 +13,46 @@ import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import io.dropwizard.testing.junit5.ResourceExtension;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
 public class DbLintResourceTest {
   private static Parser parser = new Parser();
+  private static GitState state = new GitState("",
+      "json-response",
+      "true",
+      "git@github.com:vrajat/mart.git",
+      "28010b73bae868ba252fbf2974f93d30ae189ea0",
+      "28010b7",
+      "28010b7-dirty", "28010b7-dirty",
+      "User Name",
+      "xxxxx@yyyyy.io",
+      "new:usr:Improve Dblint resource parameters and "
+          + "responses\n\nUse classes (SqlQuery and QueryResponse) instead of strings for\nREST "
+          + "calls to digest and pretty print.",
+      "new:usr:Improve Dblint resource parameters and "
+          + "responses",
+      "2018-11-22T21:24:13+0530",
+      "",
+      "",
+      "User Name",
+      "xxxxxx@yyyyyyy.io",
+      "2018-11-22T22:33:26+0530",
+      "build-machine",
+      "0.4.3-SNAPSHOT",
+      "94");
 
   private static final ObjectMapper OBJECT_MAPPER = Jackson.newObjectMapper()
       .registerModule(new GuavaModule());
 
   static final ResourceExtension RESOURCE = ResourceExtension.builder()
-      .addResource(new DbLintResource(parser))
+      .addResource(new DbLintResource(parser, state))
       .setMapper(OBJECT_MAPPER)
       .build();
 
@@ -94,6 +119,15 @@ public class DbLintResourceTest {
         response.errorMessage);
     assertFalse(response.success);
     assertNull(response.sql);
+    RESOURCE.after();
+  }
+
+  @Test
+  public void version() throws Throwable {
+    RESOURCE.before();
+    GitState state = RESOURCE.target("/api/dblint/version")
+        .request().get().readEntity(GitState.class);
+    assertEquals("0.4.3-SNAPSHOT", state.buildVersion);
     RESOURCE.after();
   }
 }


### PR DESCRIPTION
Use git-commit-id plugin to capture git state during build. All the
information is available through the API in /version. The goal is to
display this information in the frontend.